### PR TITLE
Add TouchOSC reference to include Toga lib

### DIFF
--- a/lib/mod.lua
+++ b/lib/mod.lua
@@ -86,6 +86,7 @@ function Amotion:new (arc_obj)
 	local am = {}
 	setmetatable(am, Amotion)
 
+	local arc = util.file_exists(_path.code.."toga") and include "toga/lib/togaarc" or arc
 	am.ar = arc_obj or arc.connect()
 
 	am.position = { 0.01, 0.01, 0.01, 0.01 }


### PR DESCRIPTION
The idea is simple,
use your MOD to give the possibility to those who do not have a real ARC to use it with its soft version emulated with TouchOSC.
https://github.com/wangpy/toga
Any script (even those that do not have native ARC support) can now take advantage of 4 rotary modifiers!

It shouldn't create compatibility problems, in case you could still activate the change with an additional entry in the parameters.